### PR TITLE
Fix missing TextField import

### DIFF
--- a/src/components/TimelineView.js
+++ b/src/components/TimelineView.js
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 import { BundleContext } from '../contexts/BundleContext';
 import { DataSet, Timeline } from 'vis-timeline/standalone';
 import 'vis-timeline/styles/vis-timeline-graph2d.min.css';
-import { Select, MenuItem, Chip, Box, Button, Typography } from '@mui/material';
+import { Select, MenuItem, Chip, Box, Button, Typography, TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';


### PR DESCRIPTION
## Summary
- include `TextField` when importing from Material UI in TimelineView

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888b63399c4832b89e464b38a5c2dcc