### PR TITLE
Remove debug log

### DIFF
--- a/src/components/ManageView.js
+++ b/src/components/ManageView.js
@@ -26,7 +26,6 @@ const ManageView = () => {
 
   // Debug: Log editedObj to track state changes
   useEffect(() => {
-    console.log('editedObj:', editedObj);
   }, [editedObj]);
 
   const handleAdd = () => {


### PR DESCRIPTION
## Summary
- remove debugging `console.log` from ManageView component

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888b75a9594832bba45ba2396691212