### PR TITLE
Implement simple share API server

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "server": "node server/server.js"
   },
   "browserslist": {
     "production": [

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,39 @@
+const http = require('http');
+
+function handleRequest(req, res) {
+  // basic CORS headers
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    return res.end();
+  }
+
+  if (req.method === 'POST' && req.url === '/api/share') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body);
+        console.log('Received share request', data);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+}
+
+const port = process.env.PORT || 3001;
+http.createServer(handleRequest).listen(port, () => {
+  console.log('Server listening on port', port);
+});


### PR DESCRIPTION
## Summary
- add a basic Node HTTP server providing `POST /api/share`
- expose new `npm run server` script

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888b76421fc832bbc9590b11665a5a0