### PR TITLE
Add minimal server with wallet path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Fabric CTI Sharing
+
+This repository contains tools and examples for sharing Cyber Threat Intelligence on a Hyperledger Fabric network.
+
+## Server Setup
+
+A minimal server is provided under the `server/` directory. The server expects a wallet directory to store identities used to access the network.
+
+By default, the wallet is created at `server/wallet`. You can override this location by setting the `WALLET_PATH` environment variable before starting the server.
+
+```bash
+# Start the server with the default wallet path
+npm --prefix server start
+
+# Or specify a custom wallet location
+WALLET_PATH=/path/to/wallet npm --prefix server start
+```

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fabric-cti-server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+// Determine wallet path from environment or default to ./wallet
+const walletPath = process.env.WALLET_PATH || path.join(__dirname, 'wallet');
+
+if (!fs.existsSync(walletPath)) {
+  fs.mkdirSync(walletPath, { recursive: true });
+}
+
+console.log(`Using wallet directory: ${walletPath}`);
+
+// Placeholder for server implementation
+// e.g., Express or Fabric gateway initialization


### PR DESCRIPTION
## Summary
- add simple Node server in `server/` with a configurable wallet path
- add `start` script in `server/package.json`
- document server setup and wallet directory in new README

## Testing
- `node server/server.js`

------
https://chatgpt.com/codex/tasks/task_e_6888b769f1c4832b9b81ac0f631f8bad